### PR TITLE
Add booleancheckbox to accepted properties

### DIFF
--- a/lib/hubspot/deal_pipeline.rb
+++ b/lib/hubspot/deal_pipeline.rb
@@ -34,6 +34,14 @@ module Hubspot
         response = Hubspot::Connection.get_json(PIPELINES_PATH, {})
         response.map { |p| new(p) }
       end
+
+      # Creates a DealPipeline
+      # {https://developers.hubspot.com/docs/methods/deal-pipelines/create-deal-pipeline}
+      # @return [Hubspot::PipeLine] Company record
+      def create!(post_data={})
+        response = Hubspot::Connection.post_json(PIPELINES_PATH, params: {}, body: post_data)
+        new(response)
+      end
     end
 
     def [](stage)

--- a/lib/hubspot/deal_pipeline.rb
+++ b/lib/hubspot/deal_pipeline.rb
@@ -44,6 +44,13 @@ module Hubspot
       end
     end
 
+    # Destroys deal_pipeline
+    # {http://developers.hubspot.com/docs/methods/companies/delete_company}
+    # @return [TrueClass] true
+    def destroy!
+      Hubspot::Connection.delete_json(PIPELINE_PATH, pipeline_id: @pipeline_id)
+    end
+
     def [](stage)
       @stages[stage]
     end

--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -4,7 +4,7 @@ module Hubspot
     PROPERTY_SPECS = {
       group_field_names: %w(name displayName displayOrder properties),
       field_names:       %w(name groupName description fieldType formField type displayOrder label options),
-      valid_field_types: %w(textarea select text date file number radio checkbox),
+      valid_field_types: %w(textarea select text date file number radio checkbox booleancheckbox),
       valid_types:       %w(string number bool datetime enumeration),
       options:           %w(description value label hidden displayOrder)
     }

--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -3,7 +3,7 @@ module Hubspot
 
     PROPERTY_SPECS = {
       group_field_names: %w(name displayName displayOrder properties),
-      field_names:       %w(name groupName description fieldType formField type displayOrder label options),
+      field_names:       %w(name groupName description fieldType formField type displayOrder label options showCurrencySymbol),
       valid_field_types: %w(textarea select text date file number radio checkbox booleancheckbox),
       valid_types:       %w(string number bool datetime enumeration),
       options:           %w(description value label hidden displayOrder)

--- a/spec/live/deal_pipeline_spec.rb
+++ b/spec/live/deal_pipeline_spec.rb
@@ -1,0 +1,35 @@
+describe 'Deals pipeline API Live test', live: true do
+
+  before do
+    Hubspot.configure hapikey: 'demo'
+  end
+
+  let(:params) do
+    {
+      'label' => 'auto pipeline1',
+      'stages' => [
+        {
+          'label' => 'initial state',
+          'displayOrder' => 0,
+          'probability' => 0.5
+        },
+        {
+          'label' => 'next state',
+          'displayOrder' => 1,
+          'probability' => 0.9
+        }
+      ]
+    }
+  end
+
+  it 'should create, find, update and destroy' do
+    pipeline = Hubspot::DealPipeline.create!(params)
+
+    expect(pipeline.label).to eql 'auto pipeline1'
+    expect(pipeline.stages.size).to eql 2
+    expect(pipeline.stages.first['label']).to eql 'initial state'
+    expect(pipeline.stages[1]['label']).to eql 'next state'
+
+    pipeline.destroy!
+  end
+end


### PR DESCRIPTION
This pull requests adds the following functionality:

* Adds the ability to add a `single on/of checkbox` to a form using the api.
* Adds the ability to add a `currency` type to a company using the api.
* Adds the abililty to create a deal pipeline.